### PR TITLE
CAPI-174 Update deployment URL

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -10416,7 +10416,7 @@ async function postDeploymentDetails(cloudhub_env, cloudhub_app_name, is_success
 	try {		
 		const response = await axios({
             method: "post",
-            url: `https://api.invitationhomes.com/ci-cd/v1/deployments`,
+            url: `https://ci-cd-api.invitationhomes.com/v1/deployments`,
             headers: {
                 'Authorization': `Bearer ${process.env.CI_CD_API_TOKEN}`
             },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mulesoft-deploy-action",
-  "version": "1.1.0",
-  "description": "A GitHub Action that deploys release artifacts to Mulesoft Cloudhub",
+  "version": "1.1.1",
+  "description": "A GitHub Action that deploys release artifacts to MuleSoft CloudHub",
   "main": "index.js",
   "scripts": {
     "build": "ncc build src/index.js -o dist",

--- a/src/index.js
+++ b/src/index.js
@@ -167,7 +167,7 @@ async function postDeploymentDetails(cloudhub_env, cloudhub_app_name, is_success
 	try {		
 		const response = await axios({
             method: "post",
-            url: `https://api.invitationhomes.com/ci-cd/v1/deployments`,
+            url: `https://ci-cd-api.invitationhomes.com/v1/deployments`,
             headers: {
                 'Authorization': `Bearer ${process.env.CI_CD_API_TOKEN}`
             },


### PR DESCRIPTION
Use the new CI/CD API Gateway instead of the legacy endpoint on our Main API Gateway. This will allow us to eventually delete this endpoint from the Main API Gateway.

The same API token will work on both gateways, so this change is safe.
